### PR TITLE
Add support for python 3

### DIFF
--- a/debug_toolbar_mongo/operation_tracker.py
+++ b/debug_toolbar_mongo/operation_tracker.py
@@ -2,8 +2,11 @@ import functools
 import time
 import inspect
 import os
-import SocketServer
-
+try:
+    import SocketServer
+except:
+    import socketserver
+           
 import django
 from django.conf import settings
 


### PR DESCRIPTION
The SocketServer module is renamed to socketserver in python3